### PR TITLE
Implementing highlight functionality for AnimatedSprites

### DIFF
--- a/src/AnimatedSprite.cpp
+++ b/src/AnimatedSprite.cpp
@@ -70,6 +70,14 @@ std::uint16_t AnimatedSprite::timestep()
     return 0;
 }
 
+sf::FloatRect AnimatedSprite::getGlobalBounds() const
+{
+    const auto textureRect = _sprite.getTextureRect();
+    float width = static_cast<float>(std::abs(textureRect.width));
+    float height = static_cast<float>(std::abs(textureRect.height));
+    return getTransform().transformRect(sf::FloatRect(0.f, 0.f, width, height));
+}
+
 void AnimatedSprite::setHighlight(bool h)
 {
     if (h)

--- a/src/AnimatedSprite.cpp
+++ b/src/AnimatedSprite.cpp
@@ -64,6 +64,8 @@ std::uint16_t AnimatedSprite::timestep()
             _animeCallback();
         }
 
+        _highlight.setPosition(getPosition());
+
         _timer.restart();
     }
 
@@ -82,7 +84,9 @@ void AnimatedSprite::setHighlight(bool h)
 {
     if (h)
     {
-        _highlight.setSize(sf::Vector2f{ _size });
+        _highlight.setPosition(getPosition());
+        auto b = getGlobalBounds();
+        _highlight.setSize(sf::Vector2f{ b.width, b.height });
     }
     else
     {
@@ -95,7 +99,7 @@ void AnimatedSprite::draw(sf::RenderTarget & target, sf::RenderStates states) co
 {
     states.transform *= getTransform();
     target.draw(_sprite, states);
-    target.draw(_highlight, states);
+    target.draw(_highlight);
 }
 
 } // namespace tt

--- a/src/AnimatedSprite.cpp
+++ b/src/AnimatedSprite.cpp
@@ -18,7 +18,6 @@ AnimatedSprite::AnimatedSprite(const sf::Texture& texture, const sf::Vector2i& s
     _highlight.setOutlineThickness(2);
     _highlight.setOutlineColor(sf::Color(255, 255, 255));
     _highlight.setSize(sf::Vector2f{ size });
-    _highlight.setPosition(20, 20);
 }
 
 void AnimatedSprite::setSource(std::uint32_t x, std::uint32_t y)

--- a/src/AnimatedSprite.cpp
+++ b/src/AnimatedSprite.cpp
@@ -5,18 +5,27 @@
 namespace tt
 {
 
+constexpr auto HIGHLIGHT_WIDTH = 32;
+constexpr auto HIGHLIGHT_HEIGHT = 32;
+
 AnimatedSprite::AnimatedSprite(const sf::Texture& texture, const sf::Vector2i& size)
     :   _size{ size }
 {
-    setTexture(texture);
-    setTextureRect(sf::IntRect(0, 0, _size.x, _size.y));
+    _sprite.setTexture(texture);
+    _sprite.setTextureRect(sf::IntRect(0, 0, _size.x, _size.y));
+
+    _highlight.setFillColor(sf::Color::Transparent);
+    _highlight.setOutlineThickness(2);
+    _highlight.setOutlineColor(sf::Color(255, 255, 255));
+    _highlight.setSize(sf::Vector2f{ size });
+    _highlight.setPosition(20, 20);
 }
 
 void AnimatedSprite::setSource(std::uint32_t x, std::uint32_t y)
 {
     _source.x = x;
     _source.y = y;
-    setTextureRect(sf::IntRect(
+    _sprite.setTextureRect(sf::IntRect(
         _source.x * _size.x, _source.y * _size.y, _size.x, _size.y));
 }
 
@@ -45,7 +54,7 @@ std::uint16_t AnimatedSprite::timestep()
         left++;
 
         auto textureWidth = _maxFramesPerRow > 0 ?
-            _maxFramesPerRow * _size.x : getTexture()->getSize().x;
+            _maxFramesPerRow * _size.x : _sprite.getTexture()->getSize().x;
 
         if (textureWidth <= static_cast<std::uint32_t>(left * _size.x))
         {
@@ -63,6 +72,26 @@ std::uint16_t AnimatedSprite::timestep()
     }
 
     return 0;
+}
+
+void AnimatedSprite::setHighlight(bool h)
+{
+    if (h)
+    {
+        _highlight.setSize(sf::Vector2f(HIGHLIGHT_WIDTH, HIGHLIGHT_WIDTH));
+    }
+    else
+    {
+        _highlight.setSize(sf::Vector2f{ 0.f, 0.f });
+    }
+
+}
+
+void AnimatedSprite::draw(sf::RenderTarget & target, sf::RenderStates states) const
+{
+    states.transform *= getTransform();
+    target.draw(_sprite, states);
+    target.draw(_highlight, states);
 }
 
 } // namespace tt

--- a/src/AnimatedSprite.cpp
+++ b/src/AnimatedSprite.cpp
@@ -5,9 +5,6 @@
 namespace tt
 {
 
-constexpr auto HIGHLIGHT_WIDTH = 32;
-constexpr auto HIGHLIGHT_HEIGHT = 32;
-
 AnimatedSprite::AnimatedSprite(const sf::Texture& texture, const sf::Vector2i& size)
     :   _size{ size }
 {
@@ -77,7 +74,7 @@ void AnimatedSprite::setHighlight(bool h)
 {
     if (h)
     {
-        _highlight.setSize(sf::Vector2f(HIGHLIGHT_WIDTH, HIGHLIGHT_WIDTH));
+        _highlight.setSize(sf::Vector2f{ _size });
     }
     else
     {

--- a/src/AnimatedSprite.cpp
+++ b/src/AnimatedSprite.cpp
@@ -14,7 +14,6 @@ AnimatedSprite::AnimatedSprite(const sf::Texture& texture, const sf::Vector2i& s
     _highlight.setFillColor(sf::Color::Transparent);
     _highlight.setOutlineThickness(2);
     _highlight.setOutlineColor(sf::Color(255, 255, 255));
-    _highlight.setSize(sf::Vector2f{ size });
 }
 
 void AnimatedSprite::setSource(std::uint32_t x, std::uint32_t y)

--- a/src/AnimatedSprite.h
+++ b/src/AnimatedSprite.h
@@ -26,46 +26,50 @@ class AnimatedSprite :
 public:
     AnimatedSprite(const sf::Texture& texture, const sf::Vector2i& size);
 
-    void setSource(std::uint32_t x, std::uint32_t y);
-    void setState(AnimatedState state);
-    void setMaxFramesPerRow(std::uint32_t max);
-    void setAnimeCallback(AnimeCallback cb) { _animeCallback = cb; }
-
     AnimatedState state() const;
-
-    std::uint16_t timestep() override;
+    void setState(AnimatedState state);
 
     Direction direction() const { return _direction; }
     void setDirection(Direction val) { _direction = val; }
 
-    sf::FloatRect getGlobalBounds() const
-    {
-        const auto textureRect = _sprite.getTextureRect();
-        float width = static_cast<float>(std::abs(textureRect.width));
-        float height = static_cast<float>(std::abs(textureRect.height));
-        return getTransform().transformRect(sf::FloatRect(0.f, 0.f, width, height));
-    }
+    ///
+    /// \brief Set the current cell to be drawn
+    ///
+    void setSource(std::uint32_t x, std::uint32_t y);
 
+    ///
+    /// \brief  Set the max width in terms of cells for a
+    ///         given row. The animation will cycle through
+    ///         this number of cells
+    ///
+    void setMaxFramesPerRow(std::uint32_t max);
     void setHighlight(bool h);
+    void setAnimeCallback(AnimeCallback cb) { _animeCallback = cb; }
+
+    sf::FloatRect getGlobalBounds() const;
+
+    std::uint16_t timestep() override;
 
 protected:
     void draw(sf::RenderTarget& target, sf::RenderStates states) const override final;
 
-    AnimatedState   _state = AnimatedState::STILL;
-    Direction       _direction = Direction::DOWN;
-    sf::Vector2i    _size;
-    sf::Vector2i    _source;
-    sf::Clock       _timer;
+    const sf::Vector2i      _size; // fixed cell size of each frame within the sprite
+
+    AnimatedState           _state = AnimatedState::STILL;
+    Direction               _direction = Direction::DOWN;
+    sf::Vector2i            _source;
+    sf::Clock               _timer;
 
     // some sprite sheets have different frames per row
     // so this allows us to adjust how many frames get
     // animated in a particular row
-    std::uint32_t   _maxFramesPerRow = 0;
+    std::uint32_t           _maxFramesPerRow = 0;
 
-    AnimeCallback   _animeCallback;
+    AnimeCallback           _animeCallback;
 
-    sf::Sprite          _sprite;
-    sf::RectangleShape  _highlight;
+    sf::Sprite              _sprite;
+    sf::RectangleShape      _highlight;
+
 };
 
 } // namespace tt

--- a/src/AnimatedSprite.h
+++ b/src/AnimatedSprite.h
@@ -18,7 +18,8 @@ using AnimatedSpritePtr = std::shared_ptr<AnimatedSprite>;
 using AnimeCallback = std::function<void()>;
 
 class AnimatedSprite :
-    public sf::Sprite,
+    public sf::Drawable,
+    public sf::Transformable,
     public IUpdateable
 {
 
@@ -37,7 +38,18 @@ public:
     Direction direction() const { return _direction; }
     void setDirection(Direction val) { _direction = val; }
 
+    sf::FloatRect getGlobalBounds() const
+    {
+        const auto textureRect = _sprite.getTextureRect();
+        float width = static_cast<float>(std::abs(textureRect.width));
+        float height = static_cast<float>(std::abs(textureRect.height));
+        return getTransform().transformRect(sf::FloatRect(0.f, 0.f, width, height));
+    }
+
+    void setHighlight(bool h);
+
 protected:
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override final;
 
     AnimatedState   _state = AnimatedState::STILL;
     Direction       _direction = Direction::DOWN;
@@ -51,6 +63,9 @@ protected:
     std::uint32_t   _maxFramesPerRow = 0;
 
     AnimeCallback   _animeCallback;
+
+    sf::Sprite          _sprite;
+    sf::RectangleShape  _highlight;
 };
 
 } // namespace tt

--- a/src/AnimatedSprite.h
+++ b/src/AnimatedSprite.h
@@ -43,7 +43,11 @@ public:
     ///         this number of cells
     ///
     void setMaxFramesPerRow(std::uint32_t max);
+    
     void setHighlight(bool h);
+    bool highlighted() const { return _highlight.getSize().x != 0; }
+    sf::RectangleShape& highlight() { return _highlight; }
+
     void setAnimeCallback(AnimeCallback cb) { _animeCallback = cb; }
 
     sf::FloatRect getGlobalBounds() const;

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -9,7 +9,6 @@ namespace tt
         : AnimatedSprite(texture, size),
             _id { id }
     {
-        _isObtainable = false;
     }
 
     std::string Item::getID() const

--- a/src/Item.h
+++ b/src/Item.h
@@ -38,7 +38,7 @@ namespace tt
             std::string _id;
             std::string _name;
             std::string _description;
-            bool        _isObtainable;
+            bool        _isObtainable = false;
 
     };
 


### PR DESCRIPTION
Nothing is highlighted by default. `setHighlight(true);` must be called.