### PR TITLE
Fix build deps on Ubuntu 22.04

### DIFF
--- a/tools/linux/install-deps-ubuntu-22.04.sh
+++ b/tools/linux/install-deps-ubuntu-22.04.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Install Ubuntu deps for:
+# 
+# DISTRIB_ID=Ubuntu
+# DISTRIB_RELEASE=22.04
+# DISTRIB_CODENAME=jammy
+# DISTRIB_DESCRIPTION="Ubuntu 22.04.1 LTS"
+# 
+#
+
+sudo apt-get install libgl1-mesa-dev
+sudo apt-get install libx11-xcb-dev
+sudo apt-get install libfontenc-dev
+sudo apt-get install libice-dev
+sudo apt-get install libsm-dev
+sudo apt-get install libxaw7-dev
+sudo apt-get install libxcomposite-dev
+sudo apt-get install libxcursor-dev
+sudo apt-get install libxdamage-dev
+sudo apt-get install libxft-dev
+sudo apt-get install libxi-dev
+sudo apt-get install libxinerama-dev 
+sudo apt-get install libxkbfile-dev 
+sudo apt-get install cmake-gui
+sudo apt-get install libpthread-stubs0-dev
+sudo apt-get install libgl1-mesa-dev
+sudo apt-get install libx11-dev
+sudo apt-get install libxrandr-dev
+sudo apt-get install libfreetype6-dev
+sudo apt-get install libglew1.5-dev
+sudo apt-get install libjpeg8-dev
+sudo apt-get install libsndfile1-dev
+sudo apt-get install libopenal-dev
+sudo apt-get install libxmuu-dev
+sudo apt-get install libxres-dev
+sudo apt-get install libxss-dev
+sudo apt-get install libxtst-dev
+sudo apt-get install libxv-dev
+sudo apt-get install libxvmc-dev
+sudo apt-get install libxxf86vm-dev
+sudo apt-get install libxcb-sync-dev
+sudo apt-get install libxcb-dri3-dev
+
+


### PR DESCRIPTION
Fixed build deps on Ubuntu 22.04

Not going to maintain this in the README.md anymore.

Instead I'll add a deps script for any new ubuntu releases. 